### PR TITLE
Install libtool-bin as dependency

### DIFF
--- a/toolchain.sh
+++ b/toolchain.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 sudo apt-get update
-sudo apt-get install -y git autoconf build-essential gperf bison flex texinfo libtool libncurses5-dev wget gawk libc6-dev python-serial libexpat-dev unzip
+sudo apt-get install -y git autoconf build-essential gperf bison flex texinfo libtool-bin libncurses5-dev wget gawk libc6-dev python-serial libexpat-dev unzip
 
 sudo mkdir -p /opt/Espressif
 sudo chown -R $USER /opt/Espressif
@@ -9,7 +9,7 @@ sudo chown -R $USER /opt/Espressif
 cd /opt/Espressif
 
 #Install crosstool-NG (toolchain)
-git clone --depth 1 -b lx106 git://github.com/jcmvbkbc/crosstool-NG.git 
+git clone --depth 1 -b lx106 git://github.com/jcmvbkbc/crosstool-NG.git
 cd crosstool-NG
 ./bootstrap && ./configure --prefix=`pwd` && make && make install
 ./ct-ng xtensa-lx106-elf


### PR DESCRIPTION
Otherwise the `./configure` fails with `configure: error: could not find GNU libtool >= 1.5.26`.
The package has been introduced with Ubuntu 16.04 and Debian 8.