### PR TITLE
Fixed url to download mpc

### DIFF
--- a/toolchain.sh
+++ b/toolchain.sh
@@ -11,6 +11,7 @@ cd /opt/Espressif
 #Install crosstool-NG (toolchain)
 git clone --depth 1 -b lx106 git://github.com/jcmvbkbc/crosstool-NG.git 
 cd crosstool-NG
+sed -i '/http:\/\/www.multiprecision.org\/mpc\/download/c\{ftp,http,https}:\/\/ftp.gnu.org\/gnu\/mpc' scripts/build/companion_libs/140-mpc.sh
 ./bootstrap && ./configure --prefix=`pwd` && make && make install
 ./ct-ng xtensa-lx106-elf
 ./ct-ng build


### PR DESCRIPTION
There is a problem when building croostool-ng which is already solved in the croostool-ng repository but when cloning using `-b lx106` argument it's not solved. This problem involves the instalation of mpc, which has changed to webpage to download to another one.

The workaround is to change the download URL from the file `croostool-ng/scripts/build/companion_libs/140-mpc.sh` for the new one.

